### PR TITLE
Work around Popen.wait's busy wait in gatling

### DIFF
--- a/gatling/gatling.py
+++ b/gatling/gatling.py
@@ -208,9 +208,6 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
                         done = [d for d in p_filled if d.poll() is not None]
                         if done and verbose:
                             print(f"# {my_name} CLOSED {len(done)} PROCESSES", file=sys.stderr)
-#                        else:
-#                            print("SKIPPING NOT DONE", file=sys.stderr)
-#                            break
                         for d in done:
                             if verbose and p._t0 != t1:
                                 print(f"# {my_name} CLOSED PROCESS INPUT: {p._n:,} TIME:",
@@ -221,7 +218,6 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
                             res.append(d.returncode)
                         if not done:
                             sleep(0.5)
-#                    print("AFTER LOOP", file=sys.stderr)
                 else:
                     p_open.append(p)
             else:

--- a/gatling/gatling.py
+++ b/gatling/gatling.py
@@ -125,9 +125,9 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
         n = 0
         while len(not_done) > 1 or list(selector.get_map()):
             for (fileobj, _, _, p), _ in selector.select():
-                chunk = fileobj.read(4096)
+                chunk = fileobj.read(chunk_size)
                 if chunk:
-                    i = chunk.rfind('\n') + 1
+                    i = chunk.rfind(b'\n') + 1
                     if i:
                         n += fileobj._trg.write(fileobj._buf)
                         n += fileobj._trg.write(chunk[:i])
@@ -152,14 +152,14 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
     # a buffer to be written to a child.
     p_open = []
     b_in = 0
-    buf = ''
+    buf = b''
     not_done = [0, 1]
     sel_t = None
     t0 = time()
     try:
-        for chunk in iter(lambda: stdin.read(chunk_size), ''):
+        for chunk in iter(lambda: stdin.buffer.read(chunk_size), b''):
             b_in += len(chunk)
-            i = chunk.rfind('\n') + 1
+            i = chunk.rfind(b'\n') + 1
             if i:
                 p = None
                 if round_robin:
@@ -174,11 +174,11 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
                         print(f"# {my_name} STARTED A PROCESS (1 + {running} + {len(res)}):",
                               *cmd,
                               file=sys.stderr)
-                    p = Popen(cmd, encoding=stdout.encoding, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+                    p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
                     p._n = 0
                     p._t0 = time()
-                    for fo, trg in [(p.stdout, stdout), (p.stderr, stderr)]:
-                        fo._buf = ''
+                    for fo, trg in [(p.stdout, stdout.buffer), (p.stderr, stderr.buffer)]:
+                        fo._buf = b''
                         fo._trg = trg
                         fcntl(fo, F_SETFL, fcntl(fo, F_GETFL) | O_NONBLOCK)
                         selector.register(fo, EVENT_READ, p)
@@ -208,6 +208,9 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
                         done = [d for d in p_filled if d.poll() is not None]
                         if done and verbose:
                             print(f"# {my_name} CLOSED {len(done)} PROCESSES", file=sys.stderr)
+#                        else:
+#                            print("SKIPPING NOT DONE", file=sys.stderr)
+#                            break
                         for d in done:
                             if verbose and p._t0 != t1:
                                 print(f"# {my_name} CLOSED PROCESS INPUT: {p._n:,} TIME:",
@@ -218,13 +221,14 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
                             res.append(d.returncode)
                         if not done:
                             sleep(0.5)
+#                    print("AFTER LOOP", file=sys.stderr)
                 else:
                     p_open.append(p)
             else:
                 buf += chunk
         for p in p_open:
             p.stdin.write(buf)
-            buf = ''
+            buf = b''
             p.stdin.close()
             p_filled.append(p)
     except (KeyboardInterrupt, SystemExit):

--- a/gatling/gatling.py
+++ b/gatling/gatling.py
@@ -14,7 +14,7 @@ is invoked or by an optional first argument (gatling|manifold):
  * gatling: best for commands that communicate with remote servers
    (e.g. p4)
 
- * manifold: best for commands that consume mainly local resources 
+ * manifold: best for commands that consume mainly local resources
    (e.g. md5)
 
 In manifold mode a child process is created for each block read, until
@@ -235,8 +235,16 @@ def distribute(cmd, max_bytes, max_procs, chunk_size, round_robin, verbose):
         for d in p_filled:
             d.kill()
         raise
+
+# This method, for unknown reason, leads to busy wait and an explosion in CPU consumption
+#    while p_filled:
+#        res.append(p_filled.pop(0).wait())
     while p_filled:
-        res.append(p_filled.pop(0).wait())
+        sleep(0.5)
+        tmp = [p.poll() for p in p_filled]
+        for i, rt in reversed(list(enumerate(tmp))):
+            if rt is not None:
+                res.append(p_filled.pop(i).wait())
 
     if sel_t:
         not_done.pop()

--- a/gatling/version.py
+++ b/gatling/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 35)
-VERSION_STR = '1.1.35'
+VERSION = (1, 1, 37)
+VERSION_STR = '1.1.37'
 PRODUCT = 'gatling/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = 'c1cb4c63bd786e9c4df6ec0644594904'
+PY_MD5 = '8a3ada6ef9fecb7a2690f72d696ce258'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 0, 9, 782358)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 7, 43, 296997)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/gatling/version.py
+++ b/gatling/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 23)
-VERSION_STR = '1.1.23'
+VERSION = (1, 1, 35)
+VERSION_STR = '1.1.35'
 PRODUCT = 'gatling/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = '62273bde40a3b511b729214f91457f9a'
+PY_MD5 = 'c1cb4c63bd786e9c4df6ec0644594904'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 1, 34, 33, 945519)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 0, 9, 782358)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/gatling/version.py
+++ b/gatling/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 12)
-VERSION_STR = '1.1.12'
+VERSION = (1, 1, 23)
+VERSION_STR = '1.1.23'
 PRODUCT = 'gatling/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = '70a6eb236359d531b21f81a446636233'
+PY_MD5 = '62273bde40a3b511b729214f91457f9a'
 
-TIMESTAMP = datetime.datetime(2020, 2, 10, 13, 10, 29, 516764)
-USER_NAME = 'Clarence'
-USER_EMAIL = 'clarence.gardner@salesforce.com'
+TIMESTAMP = datetime.datetime(2020, 2, 19, 1, 34, 33, 945519)
+USER_NAME = 'Philip Bergen'
+USER_EMAIL = 'pbergen@salesforce.com'

--- a/manifold/manifold.py
+++ b/manifold/manifold.py
@@ -1,9 +1,17 @@
 def main():
     import sys
     import gatling
+#    import cProfile
 
     sys.argv.insert(1, 'manifold')
+
+#    pr = cProfile.Profile()
+#    pr.enable()
     gatling.main()
+#    pr.create_stats()
+ #   pr.dump_stats(f"/tmp/manifold.prof")
+ #   print("Dumped profile in", f"/tmp/manifold.prof", file=sys.stderr)
+ #   echo -n 'sort\nstats'|python -m pstats /tmp/manifold.prof
 
 
 ##

--- a/manifold/version.py
+++ b/manifold/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 40)
-VERSION_STR = '1.1.40'
+VERSION = (1, 1, 42)
+VERSION_STR = '1.1.42'
 PRODUCT = 'manifold/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = '1b26da54c34c9c5dea03f172cbd1cca0'
+PY_MD5 = '310fb4bdb5394de6d59ea0187bfe9d97'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 0, 11, 228319)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 7, 44, 292584)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/manifold/version.py
+++ b/manifold/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 13)
-VERSION_STR = '1.1.13'
+VERSION = (1, 1, 24)
+VERSION_STR = '1.1.24'
 PRODUCT = 'manifold/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = 'c964b390c5df7758462e5ff574c586f4'
+PY_MD5 = '8eee445be3b4b4371cee5328482a25f5'
 
-TIMESTAMP = datetime.datetime(2020, 2, 10, 13, 10, 30, 149848)
-USER_NAME = 'Clarence'
-USER_EMAIL = 'clarence.gardner@salesforce.com'
+TIMESTAMP = datetime.datetime(2020, 2, 19, 1, 34, 34, 969509)
+USER_NAME = 'Philip Bergen'
+USER_EMAIL = 'pbergen@salesforce.com'

--- a/manifold/version.py
+++ b/manifold/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 1, 24)
-VERSION_STR = '1.1.24'
+VERSION = (1, 1, 40)
+VERSION_STR = '1.1.40'
 PRODUCT = 'manifold/version.py'
 
 REQ_MD5 = '66d2b20c6fa5c95ac17a05d908889c66'
-PY_MD5 = '8eee445be3b4b4371cee5328482a25f5'
+PY_MD5 = '1b26da54c34c9c5dea03f172cbd1cca0'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 1, 34, 34, 969509)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 0, 11, 228319)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/o4/o4.py
+++ b/o4/o4.py
@@ -1065,7 +1065,7 @@ def o4_status(changelist, depot):
     print(f"  - HEAD is {changelist:,d} (+{changelist-cur:,d})")
 
     keep_case = f'| {o4bin} keep --case ' if sys.platform == 'darwin' else ''
-    cmd = f"{o4bin} fstat .@{cur}| {manibin} -v o4 drop --checksum{keep_case}"
+    cmd = f"{o4bin} fstat .@{cur}| {manibin} o4 drop --checksum{keep_case}"
     print(f"Checksumming ({cmd}).")
     print("Please be patient...")
     res = run(cmd, stdout=PIPE, shell=True, universal_newlines=True)

--- a/o4/o4.py
+++ b/o4/o4.py
@@ -1086,10 +1086,10 @@ def o4_status(changelist, depot, check_all, quick):
 
     os.environ['O4_PROGRESS'] = 'false'
     keep_case = f'| {o4bin} keep --case' if sys.platform == 'darwin' else ''
-    drop_deleted = f"| grep -v ',$' " if not check_all else ''
+    drop_deleted = f"| grep -v ',$'" if not check_all else ''
     changed = f" --changed {cur*4//5}" if quick else ''
     cmd = f"{o4bin} fstat -v .@{cur}{changed}{drop_deleted}| {manibin} o4 drop --checksum{keep_case}"
-    print(f"Checksumming ({cmd}).")
+    print(f"Checksumming ({cmd.replace('/usr/local/bin/', '')}).")
     if not check_all:
         print("Skipping deleted files.")
     if quick:
@@ -1131,7 +1131,7 @@ def o4_status(changelist, depot, check_all, quick):
         print("\nFiles with local modifications:")
         print(" (!=Checksum fail A=Added D=Deleted M=Modified O=Open R=Renamed)\n")
     else:
-        print("*** INFO: All files passed the checksum test.")
+        print("*** INFO: All files passed the checksum test and no files are open for edit.")
         return True
 
     for f in sorted(all_fnames):

--- a/o4/o4.py
+++ b/o4/o4.py
@@ -1065,7 +1065,7 @@ def o4_status(changelist, depot):
     print(f"  - HEAD is {changelist:,d} (+{changelist-cur:,d})")
 
     keep_case = f'| {o4bin} keep --case ' if sys.platform == 'darwin' else ''
-    cmd = f"{o4bin} fstat .@{cur} {keep_case}| {manibin} o4 drop --checksum"
+    cmd = f"{o4bin} fstat .@{cur}| {manibin} -v o4 drop --checksum{keep_case}"
     print(f"Checksumming ({cmd}).")
     print("Please be patient...")
     res = run(cmd, stdout=PIPE, shell=True, universal_newlines=True)

--- a/o4/o4_progress.py
+++ b/o4/o4_progress.py
@@ -54,10 +54,6 @@ def progress_iter(it, path, desc, delay=0.5, delta=500):
     Use this to wrap an iterator you would like to present progress
     for.
     """
-    if not progress_enabled():
-        for line in it:
-            yield line
-        return
     with open(swap_filename(path), 'wt') as pout:
         try:
             for n, r in enumerate(it):
@@ -70,6 +66,14 @@ def progress_iter(it, path, desc, delay=0.5, delta=500):
             pout.seek(0)
             pout.truncate()
             print("-", file=pout)
+
+
+def progress_off_iter(it, path, desc, delay=0.5, delta=500):
+    return it
+
+
+if not progress_enabled():
+    progress_iter = progress_off_iter
 
 
 def progress_show(path, delay=0.45):

--- a/o4/version.py
+++ b/o4/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 2, 185)
-VERSION_STR = '1.2.185'
+VERSION = (1, 2, 188)
+VERSION_STR = '1.2.188'
 PRODUCT = 'o4/version.py'
 
 REQ_MD5 = '43a9b7190217ebf4434beeb068e7a833'
-PY_MD5 = '06f4ca7a8aabda4b9203fb197f8d3c0a'
+PY_MD5 = '729f1b1fda0e737fff2c8b38523d974e'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 4, 24, 24, 578042)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 4, 27, 39, 913696)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/o4/version.py
+++ b/o4/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 2, 160)
-VERSION_STR = '1.2.160'
+VERSION = (1, 2, 166)
+VERSION_STR = '1.2.166'
 PRODUCT = 'o4/version.py'
 
 REQ_MD5 = '43a9b7190217ebf4434beeb068e7a833'
-PY_MD5 = 'b53860e9d296df5442dc32a234497fe4'
+PY_MD5 = 'f0198ba32435de70fbb460a83fd1bf59'
 
-TIMESTAMP = datetime.datetime(2020, 2, 18, 22, 12, 46, 908393)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 4, 6, 837547)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/o4/version.py
+++ b/o4/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 2, 167)
-VERSION_STR = '1.2.167'
+VERSION = (1, 2, 185)
+VERSION_STR = '1.2.185'
 PRODUCT = 'o4/version.py'
 
 REQ_MD5 = '43a9b7190217ebf4434beeb068e7a833'
-PY_MD5 = '615167011b1d06212d25e3d22cb8f89a'
+PY_MD5 = '06f4ca7a8aabda4b9203fb197f8d3c0a'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 8, 38, 464026)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 4, 24, 24, 578042)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'

--- a/o4/version.py
+++ b/o4/version.py
@@ -3,13 +3,13 @@
 
 import datetime
 
-VERSION = (1, 2, 166)
-VERSION_STR = '1.2.166'
+VERSION = (1, 2, 167)
+VERSION_STR = '1.2.167'
 PRODUCT = 'o4/version.py'
 
 REQ_MD5 = '43a9b7190217ebf4434beeb068e7a833'
-PY_MD5 = 'f0198ba32435de70fbb460a83fd1bf59'
+PY_MD5 = '615167011b1d06212d25e3d22cb8f89a'
 
-TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 4, 6, 837547)
+TIMESTAMP = datetime.datetime(2020, 2, 19, 3, 8, 38, 464026)
 USER_NAME = 'Philip Bergen'
 USER_EMAIL = 'pbergen@salesforce.com'


### PR DESCRIPTION
This, at the very end, Popen.wait is a busy wait:
```
   while p_filled:
        print("LOOP", len(res), file=sys.stderr)
        res.append(p_filled.pop(0).wait())
```
LOOP prints very slowly 16 times. 100% cpu. If I use poll instead, 0% CPU.


Changing to poll: `gatling -m 131072 o4 pyforce sync -f >| /dev/null 30.08s user 74.23s system 59% cpu 2:55.51 total`
Before: `gatling -m 131072 o4 pyforce sync -f >| /dev/null 164.17s user 97.48s system 132% cpu 3:17.95 total`

That's a 12% reduction in wall clock time and a 82% reduction in CPU time. It makes my code look stupid, but I will have to live with that. 😄 